### PR TITLE
Fix mailbox select lore

### DIFF
--- a/src/main/java/eu/pb4/polydecorations/block/item/MailboxBlockEntity.java
+++ b/src/main/java/eu/pb4/polydecorations/block/item/MailboxBlockEntity.java
@@ -231,7 +231,7 @@ public class MailboxBlockEntity extends LockableBlockEntity implements OwnedBloc
 
                 for (var stack : entry.getValue().heldStacks) {
                     if (!stack.isEmpty()) {
-                        b.addLoreLine(Text.translatable("container.shulkerBox.itemCount", stack.getName(), String.valueOf(stack.getCount())).formatted(Formatting.GRAY));
+                        b.addLoreLine(Text.translatable("item.container.item_count", stack.getName(), String.valueOf(stack.getCount())).formatted(Formatting.GRAY));
                     }
                 }
 


### PR DESCRIPTION
`container.shulkerBox.itemCount` has been deprecated in favor of `item.container.item_count`